### PR TITLE
libgcrypt: fixes process() not returning std:nullopt when main loop fails

### DIFF
--- a/modules/libgcrypt/module.cpp
+++ b/modules/libgcrypt/module.cpp
@@ -376,9 +376,9 @@ namespace libgcrypt_detail {
                     CF_CHECK_EQ(gcry_cipher_decrypt(h, out + outIdx, outputBufferSize - outIdx, part.first, part.second), GPG_ERR_NO_ERROR);
                 }
                 outIdx += part.second;
-
-                ret = outIdx;
             }
+
+            ret = outIdx;
 
         end:
             return ret;


### PR DESCRIPTION
`process()` could return a value even when the main encryption/decryption loop failed.

This causes e.g. encryption to return a truncated ciphertext when the output buffer is too short and the loop iterates at least once, setting `ret`.