### PR TITLE
Improve documentation on Cryptofuzz

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 ## Documentation
 
-Documentation on how to implement modules and use Cryptofuzz will follow.
+For building Cryptofuzz, please refer to [`docs/building.md`](docs/building.md).
+
+For instructions on how to run Cryptofuzz, please see [`docs/running.md`](docs/running.md).
 
 ## Hall of Fame
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -1,32 +1,62 @@
 # Building Cryptofuzz
 
-## Preparation
+There are three main steps in building Cryptofuzz to begin fuzzing:
+
+ 1. Generating Cryptofuzz Headers
+ 2. Building Cryptographic Libraries and Cryptofuzz Modules
+ 3. Building Cryptofuzz
+
+## 1. Generating Cryptofuzz Headers
 
 Run:
 
-```python gen_repository.py```
+```sh
+python2 gen_repository.py
+```
 
 to generate look-up tables required for the compilation of Cryptofuzz.
 
-Set the fuzzing engine:
+If you don't, you'll typically see an error message like:
 
-```sh
-export LIBFUZZER_LINK="-fsanitize=fuzzer"
-```
+    include/cryptofuzz/repository.h:23:10: fatal error: ../../repository_tbl.h: No such file or directory
+       23 | #include "../../repository_tbl.h"
+          |          ^~~~~~~~~~~~~~~~~~~~~~~~
 
-Recommended compilation flags for both Cryptofuzz and cryptographic libraries are:
+## 2. Building Cryptographic Libraries and Cryptofuzz Modules
+
+Refer to the following documentation for building your desired set of
+libraries. Note that Cryptofuzz is built around differential fuzzing;
+having multiple libraries for a given primitive is helpful in finding
+bugs.
+
+When building Cryptofuzz and cryptographic libraries, the suggested
+compilation flags are:
 
 ```sh
 export CFLAGS="-fsanitize=address,undefined,fuzzer-no-link -O2 -g"
 export CXXFLAGS="-fsanitize=address,undefined,fuzzer-no-link -D_GLIBCXX_DEBUG -O2 -g"
 ```
 
-## Building modules
+Some libraries might also require `-Wl,--unresolved-symbols=ignore-all` in
+order to build successfully.
 
-For library-specific build instructions, please refer to:
+Available library-specific build instructions:
 
-[OpenSSL, LibreSSL, BoringSSL](openssl.md)
+ - [OpenSSL, LibreSSL, BoringSSL](openssl.md)
+ - [Botan](botan.md)
+ - [Crypto++](cryptopp.md)
+ - [NSS](nss.md)
 
-[Botan](botan.md)
+## 3. Building Cryptofuzz
 
-[Crypto++](cryptopp.md)
+Set the fuzzing engine link:
+
+```sh
+export LIBFUZZER_LINK="-fsanitize=fuzzer"
+```
+
+Then, build Cryptofuzz:
+
+```sh
+make
+```

--- a/docs/nss.md
+++ b/docs/nss.md
@@ -1,0 +1,32 @@
+# NSS
+
+## Library compilation
+
+```sh
+mkdir sandbox && cd sandbox/
+hg clone https://hg.mozilla.org/projects/nspr
+hg clone https://hg.mozilla.org/projects/nss
+cd nss
+
+# FIXUP fuzz.gyp to remove reference to unavailable FuzzingEngine.
+sed '/-lFuzzingEngine/d' fuzz/fuzz.gyp -i
+
+export LDFLAGS="-Wl,--unresolved-symbols=ignore-all"
+
+# Note that build.sh might fail because it tries to build additional
+# utilities that aren't compatible with fuzzing.
+./build.sh --clang --enable-fips --static --asan --disable-tests --fuzz=oss
+
+# Optional, to ensure that the required modules were built
+ninja -C out/Debug nss_static_libs nss_static
+
+export CXXFLAGS="$CXXFLAGS -I $NSS_NSPR_PATH/dist/public/nss -I $NSS_NSPR_PATH/dist/Debug/include/nspr -DCRYPTOFUZZ_NSS"
+export NSS_NSPR_PATH="$(realpath ..)"
+```
+
+## Module compilation
+
+```sh
+cd cryptofuzz/modules/nss/
+make
+```

--- a/docs/running.md
+++ b/docs/running.md
@@ -1,0 +1,20 @@
+# Running Cryptofuzz
+
+For instructions on how to build Cryptofuzz, see [building.md](building.md).
+
+Cryptofuzz is a [libFuzzer](https://llvm.org/docs/LibFuzzer.html) front-end
+for differential fuzzing of various cryptographic libraries.
+
+Once built, the `cryptofuzz` executable behaves like a standard libFuzzer
+interface:
+
+ - Pass `-help=1` to see available options.
+ - Use `-jobs=<n>` and `-workers=<n>` to control the number of processes used.
+ - Run `./cryptofuzz /path/to/corpus` to begin fuzzing. Crashes will be saved
+   to `crash-<hash>`.
+ - Run `./cryptofuzz --debug /path/to/crash-<hash>` to see what operations
+   were performed to cause the crash.
+
+You can use `./generate_corpus /path/to/directory` to generate a starting
+corpus, but be warned, this may generate a lot of small files taking up lots
+of inodes!


### PR DESCRIPTION
This includes:

 - Rewording and restructuring docs/building.md
 - Introducing NSS-specific build instructions
 - Add docs/running.md to give an overview of libFuzzer usage
 - Update the README to point at the new documentation

`Signed-off-by: Alexander Scheel <alexander.m.scheel@gmail.com>`