### PR TITLE
Fix CMAC fuzzing

### DIFF
--- a/gen_repository.py
+++ b/gen_repository.py
@@ -335,6 +335,7 @@ ciphers.Add( Cipher("CAST5_CFB") )
 ciphers.Add( Cipher("CAST5_ECB") )
 ciphers.Add( Cipher("CAST5_OFB") )
 ciphers.Add( Cipher("CHACHA20") )
+ciphers.Add( Cipher("DES") )
 # DESX_A/DESX_B: See https://github.com/openssl/openssl/issues/9703#issuecomment-526197301
 ciphers.Add( Cipher("DESX_A_CBC") )
 ciphers.Add( Cipher("DESX_B_CBC") )

--- a/modules/botan/module.cpp
+++ b/modules/botan/module.cpp
@@ -255,7 +255,7 @@ end:
 } /* namespace Botan_detail */
 
 std::optional<component::MAC> Botan::OpCMAC(operation::CMAC& op) {
-    if ( op.cipher.cipherType.Get() != CF_CIPHER("AES_128_CBC") ) {
+    if ( op.cipher.cipherType.Get() != CF_CIPHER("AES") ) {
         return {};
     }
     Datasource ds(op.modifier.GetPtr(), op.modifier.GetSize());

--- a/modules/nss/module.cpp
+++ b/modules/nss/module.cpp
@@ -193,12 +193,8 @@ std::optional<component::MAC> NSS::OpCMAC(operation::CMAC& op) {
     ret = component::MAC(output.data(), output.size());
 
 end:
-    if ( p11_key != nullptr ) {
-        PK11_FreeSymKey(p11_key);
-    }
-    if ( slot != nullptr ) {
-        PK11_FreeSlot(slot);
-    }
+    PK11_FreeSymKey(p11_key);
+    PK11_FreeSlot(slot);
 
     return ret;
 }


### PR DESCRIPTION
This does two things:

 1. Introduces the plain DES cipher. We still need to introduces DES3 at some point.
 2. Fix CMAC+AES by setting IsAES=True for the plain "AES" cipher.

Please see the commit message for the second commit. I'm quite confused why that change helps, but according to ample `printf` statements, it does. I'd appreciate your review on it. 
