### PR TITLE
Update bn_ops with change in mp_exch for wolfCrypt

### DIFF
--- a/modules/wolfcrypt/bn_ops.cpp
+++ b/modules/wolfcrypt/bn_ops.cpp
@@ -901,15 +901,8 @@ bool Set::Run(Datasource& ds, Bignum& res, BignumCluster& bn) const {
                 /* mp_exch alters the value of bn[0], so invalidate the cache. */
                 bn.InvalidateCache();
 
-                /* mp_exch only returns a value when wolfCrypt is compiled
-                 * with fast math; it does not return a value when compiled
-                 * with --disable-fastmath or SP math.
-                 */
-#if defined(USE_FAST_MATH) || defined(WOLFSSL_SP_MATH)
+                /* mp_exch always returns a value */
                 MP_CHECK_EQ(mp_exch(res.GetPtr(), bn[0].GetPtr()), MP_OKAY);
-#else
-                CF_NORET(mp_exch(res.GetPtr(), bn[0].GetPtr()));
-#endif
 
                 ret = true;
             }


### PR DESCRIPTION
In wolfCrypt, we changed the return code on integer.c:mp_exch() from void to int. Needed to update the assertion.