### PR TITLE
Restore RELIC build after interface update.

### DIFF
--- a/modules/relic/bn_ops.cpp
+++ b/modules/relic/bn_ops.cpp
@@ -206,10 +206,18 @@ bool LShift1::Run(Datasource& ds, Bignum& res, std::vector<Bignum>& bn) const {
 bool Jacobi::Run(Datasource& ds, Bignum& res, std::vector<Bignum>& bn) const {
     (void)ds;
 
-    RLC_TRY {
-        /* noret */ bn_smb_jac(res.Get(), bn[0].Get(), bn[1].Get());
+    int resInt;
+
+    try {
+        resInt = bn_smb_jac(bn[0].Get(), bn[1].Get());
     } RLC_CATCH_ANY {
         return false;
+    }
+
+    if ( resInt == -1 ) {
+	res.Set("-1");
+    } else {
+	res.Set(resInt);
     }
 
     return true;


### PR DESCRIPTION
This hopefully restores the RELIC build after the API update in the Jacobi symbol functions.

I was not able to compile cryptofuzz locally, but I hope I got it right on first try (unlikely).