### PR TITLE
Fuzz |EVP_aes_256_xts| when |CRYPTOFUZZ_AWSLC| is defined.

### DIFF
--- a/modules/openssl/module.cpp
+++ b/modules/openssl/module.cpp
@@ -314,6 +314,10 @@ const EVP_CIPHER* OpenSSL::toEVPCIPHER(const component::SymmetricCipherType ciph
             return EVP_aes_256_gcm();
         case CF_CIPHER("RC4"):
             return EVP_rc4();
+#if defined(CRYPTOFUZZ_AWSLC)
+        case CF_CIPHER("AES_256_XTS"):
+            return EVP_aes_256_xts();
+#endif
 #elif defined(CRYPTOFUZZ_LIBRESSL)
         case CF_CIPHER("DES_CFB"):
             return EVP_des_cfb();


### PR DESCRIPTION
### Background

[AWS-LC](https://github.com/awslabs/aws-lc) is a general-purpose cryptographic library based on code from the Google BoringSSL project and the OpenSSL project. The ciphers/digests enabled by `CRYPTOFUZZ_BORINGSSL` are applicable to AWS-LC.

### Description of this change
AWS-LC moved `|EVP_aes_256_xts|` code from `libdecrepit` to `libcrypto`. `CRYPTOFUZZ_AWSLC` is added to fuzz this cipher. 

### Tests
Some debug statements were added inside `aes_xts_cipher` of AWS-LC. The statements got print out during fuzzing.

### Next steps
* I will submit new PRs to add more formal support of `CRYPTOFUZZ_AWSLC`. e.g.
  * Expand `#if defined(CRYPTOFUZZ_BORINGSSL)` to `#if defined(CRYPTOFUZZ_BORINGSSL) || #if defined(CRYPTOFUZZ_AWSLC)`.
  * Add related README.