### PR TITLE
LibreSSL uppercased x25519_public_from_private()

### DIFF
--- a/modules/openssl/module.cpp
+++ b/modules/openssl/module.cpp
@@ -16,8 +16,7 @@
 #if defined(CRYPTOFUZZ_BORINGSSL)
 #include <openssl/curve25519.h>
 #elif defined(CRYPTOFUZZ_LIBRESSL)
-extern "C" { void x25519_public_from_private(uint8_t out_public_value[32], const uint8_t private_key[32]); }
-#define X25519_public_from_private x25519_public_from_private
+extern "C" { void X25519_public_from_private(uint8_t out_public_value[32], const uint8_t private_key[32]); }
 #else
 /* OpenSSL */
 extern "C" { void ossl_x25519_public_from_private(uint8_t out_public_value[32], const uint8_t private_key[32]); }


### PR DESCRIPTION
When adding Ed25519 support, we refactored a few curve25519 internals. This should fix the oss-fuzz build.