### PR TITLE
libsecp256k1: remove secp256k1_fe_equal_var

### DIFF
--- a/modules/secp256k1/module.cpp
+++ b/modules/secp256k1/module.cpp
@@ -1531,13 +1531,7 @@ end:
                 break;
             case    CF_CALCOP("IsEq(A,B)"):
                 {
-                    bool var = false;
-                    try { var = ds.Get<bool>(); } catch ( ... ) { }
-
-                    const int r =
-                        var == false ?
-                            cryptofuzz_secp256k1_fe_equal(a, b) :
-                            cryptofuzz_secp256k1_fe_equal_var(a, b);
+                    const int r = cryptofuzz_secp256k1_fe_equal(a, b);
 
                     CF_NORET(cryptofuzz_secp256k1_fe_set_int(res, r));
                 }

--- a/modules/secp256k1/secp256k1_api.c
+++ b/modules/secp256k1/secp256k1_api.c
@@ -145,10 +145,6 @@ int cryptofuzz_secp256k1_fe_equal(const void *a, const void *b) {
     return secp256k1_fe_equal(a, b);
 }
 
-int cryptofuzz_secp256k1_fe_equal_var(const void *a, const void *b) {
-    return secp256k1_fe_equal_var(a, b);
-}
-
 int cryptofuzz_secp256k1_fe_cmp_var(const void *a, const void *b) {
     return secp256k1_fe_cmp_var(a, b);
 }

--- a/modules/secp256k1/secp256k1_api.h
+++ b/modules/secp256k1/secp256k1_api.h
@@ -40,7 +40,6 @@ int cryptofuzz_secp256k1_fe_is_odd(const void *a);
 int cryptofuzz_secp256k1_fe_is_zero(const void *a);
 void cryptofuzz_secp256k1_fe_clear(void *r);
 int cryptofuzz_secp256k1_fe_equal(const void *a, const void *b);
-int cryptofuzz_secp256k1_fe_equal_var(const void *a, const void *b);
 int cryptofuzz_secp256k1_fe_cmp_var(const void *a, const void *b);
 void cryptofuzz_secp256k1_fe_cmov(void *r, const void *a, const int flag);
 size_t cryptofuzz_secp256k1_fe_storage_size(void);


### PR DESCRIPTION
This was removed upstream, https://github.com/bitcoin-core/secp256k1/pull/1062, and is causing build failures downstream:
```bash
clang++ -O1 -fno-omit-frame-pointer -gline-tables-only -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=address -fsanitize-address-use-after-scope -fsanitize=fuzzer-no-link -stdlib=libc++ -DCRYPTOFUZZ_NO_OPENSSL -I /src/boost_1_74_0/ -DCRYPTOFUZZ_SECP256K1 -DCRYPTOFUZZ_TREZOR_FIRMWARE -DCRYPTOFUZZ_BOTAN -DCRYPTOFUZZ_BOTAN_IS_ORACLE -DCRYPTOFUZZ_BITCOIN -Wall -Wextra -std=c++17 -I include/ -I . -I fuzzing-headers/include -DFUZZING_HEADERS_NO_IMPL driver.o executor.o util.o entry.o tests.o operation.o datasource.o repository.o options.o components.o wycheproof.o crypto.o expmod.o mutator.o z3.o numbers.o mutatorpool.o ecc_diff_fuzzer_importer.o ecc_diff_fuzzer_exporter.o botan_importer.o openssl_importer.o builtin_tests_importer.o bignum_fuzzer_importer.o modules/botan/module.a modules/secp256k1/module.a modules/trezor/module.a modules/bitcoin/module.a -fsanitize=fuzzer third_party/cpu_features/build/libcpu_features.a  -o cryptofuzz
/usr/bin/ld: /usr/bin/ld: DWARF error: invalid or unhandled FORM value: 0x25
modules/secp256k1/module.a(secp256k1_api.o): in function `cryptofuzz_secp256k1_fe_equal_var':
secp256k1_api.c:(.text.cryptofuzz_secp256k1_fe_equal_var[cryptofuzz_secp256k1_fe_equal_var]+0x27): undefined reference to `secp256k1_fe_equal_var'
/usr/bin/ld: secp256k1_api.c:(.text.cryptofuzz_secp256k1_fe_equal_var[cryptofuzz_secp256k1_fe_equal_var]+0x39): undefined reference to `secp256k1_fe_equal_var'
clang-15: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [Makefile:59: cryptofuzz] Error 1
ERROR:__main__:Building fuzzers failed.
```