### PR TITLE
[libecc] Fix the CryptoFuzz libecc module with new headers source tree.

### DIFF
--- a/modules/libecc/Makefile
+++ b/modules/libecc/Makefile
@@ -12,6 +12,6 @@ module.a: module.o
 	ranlib module.a
 module.o: module.cpp module.h
 	test $(LIBECC_PATH)
-	$(CXX) $(CXXFLAGS) -DWITH_STDLIB -I $(LIBECC_PATH)/src -fPIC -c module.cpp -o module.o
+	$(CXX) $(CXXFLAGS) -DWITH_STDLIB -I $(LIBECC_PATH)/ -fPIC -c module.cpp -o module.o
 clean:
 	rm -rf *.o module.a

--- a/modules/libecc/module.cpp
+++ b/modules/libecc/module.cpp
@@ -8,8 +8,8 @@
 #define TOSTRING(x) STRINGIFY(x)
 
 extern "C" {
-    #include <libsig.h>
-    #include <hash/hmac.h>
+    #include <include/libecc/libsig.h>
+    #include <include/libecc/hash/hmac.h>
 }
 
 namespace cryptofuzz {


### PR DESCRIPTION
Hi,

We have changed the API headers place for `libecc`: these headers are now in the library path `include/libecc` folder (this modification is useful for the `meson` build system work in progress integration).
This calls for minor modifications in the `CryptoFuzz` dedicated module include paths and `Makefile`.

Regards,