### PR TITLE
[libecc] Fix (again) inclusion paths in libecc module (fixing PR #56).

### DIFF
--- a/modules/libecc/Makefile
+++ b/modules/libecc/Makefile
@@ -12,6 +12,6 @@ module.a: module.o
 	ranlib module.a
 module.o: module.cpp module.h
 	test $(LIBECC_PATH)
-	$(CXX) $(CXXFLAGS) -DWITH_STDLIB -I $(LIBECC_PATH)/ -fPIC -c module.cpp -o module.o
+	$(CXX) $(CXXFLAGS) -DWITH_STDLIB -I $(LIBECC_PATH)/include -fPIC -c module.cpp -o module.o
 clean:
 	rm -rf *.o module.a

--- a/modules/libecc/module.cpp
+++ b/modules/libecc/module.cpp
@@ -8,8 +8,8 @@
 #define TOSTRING(x) STRINGIFY(x)
 
 extern "C" {
-    #include <include/libecc/libsig.h>
-    #include <include/libecc/hash/hmac.h>
+    #include <libecc/libsig.h>
+    #include <libecc/hash/hmac.h>
 }
 
 namespace cryptofuzz {


### PR DESCRIPTION
Sorry for this duplicate PR, but PR #56 was not properly including the paths. This should work better (locally tested with OSS-Fuzz compilation).