### PR TITLE
Fix issue #54 regarding compilation of generate_dict

### DIFF
--- a/generate_dict.cpp
+++ b/generate_dict.cpp
@@ -3,6 +3,7 @@
 #include <sstream>
 #include <iomanip>
 #include <vector>
+#include <optional>
 #include <stdio.h>
 #include <fuzzing/datasource/id.hpp>
 #include "repository_map.h"


### PR DESCRIPTION
generate_dict includes repository_map.h which uses the optional library.
If I had to guess this gets transitively included by other
files included by generate_dict depending on your distribution's libstdc.

Original error message:

```
./repository_map.h:633:10: error: no template named 'optional' in namespace 'std'
```
