### PR TITLE
libsecp256k1: remove secp256k1_scalar_shr_int

### DIFF
--- a/modules/secp256k1/module.cpp
+++ b/modules/secp256k1/module.cpp
@@ -1437,17 +1437,6 @@ namespace secp256k1_detail {
                     CF_NORET(cryptofuzz_secp256k1_scalar_set_int(res, bin->data()[0]));
                 }
                 break;
-            case    CF_CALCOP("RShift(A,B)"):
-                {
-                    CF_CHECK_FALSE(mod);
-                    std::optional<std::vector<uint8_t>> bin;
-                    CF_CHECK_NE(bin = util::DecToBin(op.bn1.ToTrimmedString(), 1), std::nullopt);
-                    CF_CHECK_GT(bin->data()[0], 0);
-                    CF_CHECK_LT(bin->data()[0], 16);
-                    /* ignore ret */ cryptofuzz_secp256k1_scalar_shr_int(a, bin->data()[0]);
-                    memcpy(res, a, cryptofuzz_secp256k1_scalar_type_size());
-                }
-                break;
             default:
                 goto end;
         }

--- a/modules/secp256k1/secp256k1_api.c
+++ b/modules/secp256k1/secp256k1_api.c
@@ -79,10 +79,6 @@ unsigned int cryptofuzz_secp256k1_scalar_get_bits_var(const void *a, unsigned in
     return secp256k1_scalar_get_bits_var(a, offset, count);
 }
 
-int cryptofuzz_secp256k1_scalar_shr_int(void *r, int n) {
-    return secp256k1_scalar_shr_int(r, n);
-}
-
 size_t cryptofuzz_secp256k1_fe_size(void) {
     return sizeof(secp256k1_fe);
 }

--- a/modules/secp256k1/secp256k1_api.h
+++ b/modules/secp256k1/secp256k1_api.h
@@ -24,7 +24,6 @@ void cryptofuzz_secp256k1_scalar_cmov(void *r, const void *a, int flag);
 #endif
 unsigned int cryptofuzz_secp256k1_scalar_get_bits(const void *a, unsigned int offset, unsigned int count);
 unsigned int cryptofuzz_secp256k1_scalar_get_bits_var(const void *a, unsigned int offset, unsigned int count);
-int cryptofuzz_secp256k1_scalar_shr_int(void *r, int n);
 
 size_t cryptofuzz_secp256k1_fe_size(void);
 int cryptofuzz_secp256k1_fe_set_b32_limit(void *r, const unsigned char *b32);


### PR DESCRIPTION
This was removed upstream, https://github.com/bitcoin-core/secp256k1/pull/1184, and is causing build failures downstream:
```bash
clang++ -O1 -fno-omit-frame-pointer -gline-tables-only -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=address -fsanitize-address-use-after-scope -fsanitize=fuzzer-no-link -stdlib=libc++ -DCRYPTOFUZZ_NO_OPENSSL -I /src/boost_1_74_0/ -DCRYPTOFUZZ_SECP256K1 -DCRYPTOFUZZ_TREZOR_FIRMWARE -DCRYPTOFUZZ_BOTAN -DCRYPTOFUZZ_BOTAN_IS_ORACLE -DCRYPTOFUZZ_BITCOIN -Wall -Wextra -std=c++17 -I include/ -I . -I fuzzing-headers/include -DFUZZING_HEADERS_NO_IMPL bignum_fuzzer_importer.o botan_importer.o builtin_tests_importer.o components.o crypto.o datasource.o driver.o ecc_diff_fuzzer_exporter.o ecc_diff_fuzzer_importer.o entry.o executor.o expmod.o mutator.o mutatorpool.o numbers.o openssl_importer.o operation.o options.o repository.o tests.o util.o wycheproof.o z3.o modules/trezor/module.a modules/secp256k1/module.a modules/bitcoin/module.a modules/botan/module.a -fsanitize=fuzzer third_party/cpu_features/build/libcpu_features.a  -o cryptofuzz
/usr/bin/ld: /usr/bin/ld: DWARF error: invalid or unhandled FORM value: 0x25
modules/secp256k1/module.a(secp256k1_api.o): in function `cryptofuzz_secp256k1_scalar_shr_int':
secp256k1_api.c:(.text.cryptofuzz_secp256k1_scalar_shr_int[cryptofuzz_secp256k1_scalar_shr_int]+0x27): undefined reference to `secp256k1_scalar_shr_int'
/usr/bin/ld: secp256k1_api.c:(.text.cryptofuzz_secp256k1_scalar_shr_int[cryptofuzz_secp256k1_scalar_shr_int]+0x39): undefined reference to `secp256k1_scalar_shr_int'
clang-15: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [Makefile:33: cryptofuzz] Error 1
ERROR:__main__:Building fuzzers failed.
```