### PR TITLE
Add support for disable operations option

### DIFF
--- a/executor.cpp
+++ b/executor.cpp
@@ -2723,6 +2723,10 @@ void ExecutorBase<ResultType, OperationType>::Run(Datasource& parentDs, const ui
 
     do {
         auto op = getOp(&parentDs, data, size);
+        auto operationName = op.Name();
+        if(options.disableOperations.HaveExplicit(operationName)){
+            continue;
+        }
         auto module = getModule(parentDs);
         if ( module == nullptr ) {
             continue;

--- a/include/cryptofuzz/options.h
+++ b/include/cryptofuzz/options.h
@@ -9,6 +9,17 @@
 
 namespace cryptofuzz {
 
+class EnabledNames {
+    private:
+        std::set<std::string> names;
+    public:
+        bool Have(std::string name) const;
+        bool HaveExplicit(std::string name) const;
+        void Add(std::string name);
+        std::string At(const size_t index) const;
+        bool Empty(void) const;
+};
+
 class EnabledTypes {
     private:
         std::set<uint64_t> types;
@@ -28,6 +39,7 @@ class Options {
         Options(const int argc, char** argv, const std::vector<std::string> extraArguments = {});
 
         EnabledTypes operations, ciphers, digests, curves, calcOps, disableModules;
+        EnabledNames disableOperations;
         std::optional<uint64_t> forceModule = std::nullopt;
         std::optional<FILE*> jsonDumpFP = std::nullopt;
         size_t minModules = 1;


### PR DESCRIPTION
Add a option for disable operations.

I implemented `--disable-operations` option based on `--disable-modules` codes in options.cpp. 
I also added `EnabledNames` class for searching operations by names and add to `disableOperations` set.
 In executor.cpp code, I implemented function that passes operation if it is in disableOperations set.

Thanks in advance for taking a look and I'm glad to have any questions.