### PR TITLE
PSA crypto: fuzz MAC and symmetric ciphers

### DIFF
--- a/modules/tf-psa-crypto/module.cpp
+++ b/modules/tf-psa-crypto/module.cpp
@@ -170,7 +170,7 @@ namespace TF_PSA_Crypto_detail {
         if (name.rfind("DES", 0) == 0) {
             /* Only a few old-school block modes are accepted with DES. */
             if (repository::IsCBC(id)) {
-                return PSA_ALG_CBC_NO_PADDING;
+                return PSA_ALG_CBC_PKCS7;
             } else if (repository::IsECB(id)) {
                 return PSA_ALG_ECB_NO_PADDING;
             } else {
@@ -178,7 +178,7 @@ namespace TF_PSA_Crypto_detail {
             }
         }
         if (repository::IsCBC(id)) {
-            return PSA_ALG_CBC_NO_PADDING;
+            return PSA_ALG_CBC_PKCS7;
         } else if (repository::IsCCM(id)) {
             return PSA_ALG_CCM;
         } else if (name.size() >= 3 && std::equal(name.end() - 3, name.end(), "CFB")) {

--- a/modules/tf-psa-crypto/module.cpp
+++ b/modules/tf-psa-crypto/module.cpp
@@ -171,7 +171,10 @@ namespace TF_PSA_Crypto_detail {
             return PSA_ALG_CBC_NO_PADDING;
         } else if (repository::IsCCM(id)) {
             return PSA_ALG_CCM;
-        } else if (repository::IsCFB(id) && name.rfind("DES", 0) != 0) {
+        } else if (name.size() >= 3 && std::equal(name.end() - 3, name.end(), "CFB") &&
+                   name.rfind("DES", 0) != 0) {
+            /* Only CFB with segment size = block size is available in this API,
+             * not CFB1 or CFB8. */
             return PSA_ALG_CFB;
         } else if (repository::IsCTR(id)) {
             return PSA_ALG_CTR;

--- a/modules/tf-psa-crypto/module.cpp
+++ b/modules/tf-psa-crypto/module.cpp
@@ -1046,7 +1046,8 @@ std::optional<component::Ciphertext> TF_PSA_Crypto::OpSymmetricEncrypt(operation
                        output, tag)) {
         return std::nullopt;
     }
-    return component::Ciphertext(Buffer(output), component::Tag(tag));
+    auto tag_opt = op.tagSize ? std::optional(component::Tag(tag)) : std::nullopt;
+    return component::Ciphertext(Buffer(output), tag_opt);
 }
 
 std::optional<component::Cleartext> TF_PSA_Crypto::OpSymmetricDecrypt(operation::SymmetricDecrypt& op) {

--- a/modules/tf-psa-crypto/module.cpp
+++ b/modules/tf-psa-crypto/module.cpp
@@ -342,7 +342,12 @@ namespace TF_PSA_Crypto_detail {
             return PSA_CIPHER_DECRYPT_OUTPUT_SIZE(key_type, alg, input_length);
         }
         size_t update_output_size(size_t input_length) {
-            return PSA_CIPHER_UPDATE_OUTPUT_SIZE(key_type, alg, input_length);
+            size_t size = PSA_CIPHER_UPDATE_OUTPUT_SIZE(key_type, alg, input_length);
+            if (alg == PSA_ALG_CBC_PKCS7 && input_length % block_size() == 0) {
+                // Compensate for https://github.com/Mbed-TLS/mbedtls/issues/8954
+                size += block_size();
+            }
+            return size;
         }
         size_t finish_output_size() {
             return PSA_CIPHER_FINISH_OUTPUT_SIZE(key_type, alg);

--- a/modules/tf-psa-crypto/module.h
+++ b/modules/tf-psa-crypto/module.h
@@ -14,6 +14,8 @@ class TF_PSA_Crypto : public Module {
         std::optional<component::Digest> OpDigest(operation::Digest& op) override;
         std::optional<component::MAC> OpHMAC(operation::HMAC& op) override;
         std::optional<component::MAC> OpCMAC(operation::CMAC& op) override;
+        std::optional<component::Ciphertext> OpSymmetricEncrypt(operation::SymmetricEncrypt& op) override;
+        std::optional<component::Cleartext> OpSymmetricDecrypt(operation::SymmetricDecrypt& op) override;
 };
 
 } /* namespace module */

--- a/modules/tf-psa-crypto/module.h
+++ b/modules/tf-psa-crypto/module.h
@@ -12,6 +12,7 @@ class TF_PSA_Crypto : public Module {
         TF_PSA_Crypto(void);
         ~TF_PSA_Crypto(void);
         std::optional<component::Digest> OpDigest(operation::Digest& op) override;
+        std::optional<component::MAC> OpHMAC(operation::HMAC& op) override;
 };
 
 } /* namespace module */

--- a/modules/tf-psa-crypto/module.h
+++ b/modules/tf-psa-crypto/module.h
@@ -13,6 +13,7 @@ class TF_PSA_Crypto : public Module {
         ~TF_PSA_Crypto(void);
         std::optional<component::Digest> OpDigest(operation::Digest& op) override;
         std::optional<component::MAC> OpHMAC(operation::HMAC& op) override;
+        std::optional<component::MAC> OpCMAC(operation::CMAC& op) override;
 };
 
 } /* namespace module */


### PR DESCRIPTION
In the TF-PSA-Crypto module (PSA Crypto API implemented by Mbed TLS), fuzz `HMAC`, `CMAC`, `SymmetricEncrypt` and `SymmetricDecrypt` (i.e. MAC, cipher and AEAD).

This was a journey of discovery as I [struggled through the validation philosophy](https://github.com/guidovranken/cryptofuzz/issues/69). Also of learning C++. So I don't think the code is very nice and improvements are welcome.

I ran this overnight on my laptop and it didn't find anything. And it's found things (including [one functional bug](https://github.com/Mbed-TLS/mbedtls/issues/8954)) so I think it isn't ignoring too much.

Note on timing: I'm putting this out there because it's ready, but I'm going to be offline from Friday until April 8. I'm posting this expecting to do rework when I get back.
