### PR TITLE
libsecp256k1: remove secp256k1_scalar_get_bits

### DIFF
--- a/modules/secp256k1/module.cpp
+++ b/modules/secp256k1/module.cpp
@@ -1422,7 +1422,7 @@ namespace secp256k1_detail {
                     if ( var == false ) {
                         CF_NORET(cryptofuzz_secp256k1_scalar_set_int(
                                     res,
-                                    cryptofuzz_secp256k1_scalar_get_bits(a, offset, 1)));
+                                    cryptofuzz_secp256k1_scalar_get_bits_limb32(a, offset, 1)));
                     } else {
                         CF_NORET(cryptofuzz_secp256k1_scalar_set_int(
                                     res,

--- a/modules/secp256k1/secp256k1_api.c
+++ b/modules/secp256k1/secp256k1_api.c
@@ -71,8 +71,8 @@ void cryptofuzz_secp256k1_scalar_cmov(secp256k1_scalar *r, const secp256k1_scala
 }
 #endif
 
-unsigned int cryptofuzz_secp256k1_scalar_get_bits(const void *a, unsigned int offset, unsigned int count) {
-    return secp256k1_scalar_get_bits(a, offset, count);
+unsigned int cryptofuzz_secp256k1_scalar_get_bits_limb32(const void *a, unsigned int offset, unsigned int count) {
+    return secp256k1_scalar_get_bits_limb32(a, offset, count);
 }
 
 unsigned int cryptofuzz_secp256k1_scalar_get_bits_var(const void *a, unsigned int offset, unsigned int count) {

--- a/modules/secp256k1/secp256k1_api.h
+++ b/modules/secp256k1/secp256k1_api.h
@@ -22,7 +22,7 @@ void cryptofuzz_secp256k1_scalar_inverse_var(void *r, const void *x);
         !defined(SECP255K1_COMMIT_9d560f992db26612ce2630b194aef5f44d63a530)
 void cryptofuzz_secp256k1_scalar_cmov(void *r, const void *a, int flag);
 #endif
-unsigned int cryptofuzz_secp256k1_scalar_get_bits(const void *a, unsigned int offset, unsigned int count);
+unsigned int cryptofuzz_secp256k1_scalar_get_bits_limb32(const void *a, unsigned int offset, unsigned int count);
 unsigned int cryptofuzz_secp256k1_scalar_get_bits_var(const void *a, unsigned int offset, unsigned int count);
 
 size_t cryptofuzz_secp256k1_fe_size(void);


### PR DESCRIPTION
This was renamed upstream in
https://github.com/bitcoin-core/secp256k1/commit/5005abee60ad03d2967c9aadf4e25d208c90d98a
and is causing build failures downstream:
```bash
clang++ -O1 -fno-omit-frame-pointer -gline-tables-only -Wno-error=enum-constexpr-conversion -Wno-error=incompatible-function-pointer-types -Wno-error=int-conversion -Wno-error=deprecated-declarations -Wno-error=implicit-function-declaration -Wno-error=implicit-int -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION  -fprofile-instr-generate -fcoverage-mapping -pthread -Wl,--no-as-needed -Wl,-ldl -Wl,-lm -Wno-unused-command-line-argument -stdlib=libc++ -DCRYPTOFUZZ_NO_OPENSSL -I /src/boost_1_84_0/ -DCRYPTOFUZZ_SECP256K1 -DCRYPTOFUZZ_TREZOR_FIRMWARE -DCRYPTOFUZZ_BOTAN -DCRYPTOFUZZ_BOTAN_IS_ORACLE -DCRYPTOFUZZ_BITCOIN -Wall -Wextra -std=c++17 -I include/ -I . -I fuzzing-headers/include -DFUZZING_HEADERS_NO_IMPL bignum_fuzzer_importer.o botan_importer.o builtin_tests_importer.o components.o crypto.o datasource.o driver.o ecc_diff_fuzzer_exporter.o ecc_diff_fuzzer_importer.o entry.o executor.o expmod.o mutator.o mutatorpool.o numbers.o openssl_importer.o operation.o options.o repository.o tests.o util.o wycheproof.o z3.o modules/trezor/module.a modules/secp256k1/module.a modules/botan/module.a modules/bitcoin/module.a -fsanitize=fuzzer third_party/cpu_features/build/libcpu_features.a  -o cryptofuzz
/usr/bin/ld: modules/secp256k1/module.a(secp256k1_api.o): in function `cryptofuzz_secp256k1_scalar_get_bits':
/src/cryptofuzz/modules/secp256k1/secp256k1_api.c:75:(.text+0xfdf): undefined reference to `secp256k1_scalar_get_bits'
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [Makefile:33: cryptofuzz] Error 1
ERROR:__main__:Building fuzzers failed.
```