### PR TITLE
circl: Fix CIRCL Decompress G1 elements.

### DIFF
--- a/modules/circl/cryptofuzz.go
+++ b/modules/circl/cryptofuzz.go
@@ -1113,9 +1113,17 @@ func circl_BLS_Decompress_G1(in []byte) {
 
     compressed := decodeBignum(op.Compressed)
 
+    var bytes [48]byte
+    compressed.SetBytes(bytes[:])
+    bytes[0] |= 1 << 7 // set flag: compressed.
+
+    if compressed.Sign() == 0 {
+        bytes[0] |= 1 << 6 // set flag: point at infinity.
+    }
+
     a := new(bls12381.G1)
 
-    err := a.SetBytes(compressed.Bytes())
+    err := a.SetBytes(bytes[:])
     if err != nil {
         return
     }


### PR DESCRIPTION
**Context:** CIRCL follows the [zcash convention](https://docs.rs/bls12_381/latest/bls12_381/notes/serialization/index.html) to serialize elements in G1 and G2.
The fuzzer test must adhere to this convention.

**Issue:** In this case, a compressed point should be serialized as `e || x`  where:
```
e = ( c | i | y) is a 3-bit prefix indicating 
c:Compressed, i:Infinity, y:BigYCoordinate.
```
and 
```
x, be the x-coordinate of the point.
```

Currently, the fuzzer test only tries to deserialize the x-coodrdiante, without the `e` prefix.

**Solution:**
Make fuzzer test to take in account the zcash deserialization format by appending the prefix to deserialize points in G1 (G2).



