### PR TITLE
tf-psa-crypto: KDF support

### DIFF
--- a/include/cryptofuzz/util.h
+++ b/include/cryptofuzz/util.h
@@ -60,6 +60,11 @@ Multipart ToParts(fuzzing::datasource::Datasource& ds, const Buffer& buffer, con
 Multipart ToParts(fuzzing::datasource::Datasource& ds, const uint8_t* data, const size_t size, const size_t blocksize = 0);
 Multipart ToEqualParts(const Buffer& buffer, const size_t partSize);
 Multipart ToEqualParts(const uint8_t* data, const size_t size, const size_t partSize);
+
+using MultipartOutput = std::vector< std::pair<uint8_t*, size_t> >;
+MultipartOutput ToParts(fuzzing::datasource::Datasource& ds, std::vector<uint8_t>& buffer, const size_t blocksize = 0);
+MultipartOutput ToParts(fuzzing::datasource::Datasource& ds, uint8_t* data, const size_t size, const size_t blocksize = 0);
+
 std::vector<uint8_t> Pkcs7Pad(std::vector<uint8_t> in, const size_t blocksize);
 std::optional<std::vector<uint8_t>> Pkcs7Unpad(std::vector<uint8_t> in, const size_t blocksize);
 std::string ToString(const Buffer& buffer);

--- a/modules/tf-psa-crypto/module.cpp
+++ b/modules/tf-psa-crypto/module.cpp
@@ -567,6 +567,88 @@ namespace TF_PSA_Crypto_detail {
         }
     };
 
+    class KDF_input {
+    protected:
+        psa_key_derivation_step_t step;
+
+    public:
+        KDF_input(psa_key_derivation_step_t step_arg) {
+            step = step_arg;
+        }
+        virtual ~KDF_input() {
+        }
+
+        virtual psa_status_t input(psa_key_derivation_operation_t *operation) = 0;
+    };
+
+    class KDF_input_bytes : public KDF_input {
+    protected:
+        std::vector<uint8_t> data;
+
+    public:
+        KDF_input_bytes(psa_key_derivation_step_t step_arg,
+                        const std::vector<uint8_t> &data_arg)
+            : KDF_input(step_arg) {
+            data = data_arg;
+        }
+        KDF_input_bytes(psa_key_derivation_step_t step_arg,
+                        const Buffer &data_arg)
+            : KDF_input(step_arg) {
+            data = data_arg.Get();
+        }
+
+        virtual psa_status_t input(psa_key_derivation_operation_t *operation) override {
+            return psa_key_derivation_input_bytes(operation, step,
+                                                  data.data(), data.size());
+        }
+    };
+
+    class KDF_input_integer : public KDF_input {
+    protected:
+        uint64_t data;
+
+    public:
+        KDF_input_integer(psa_key_derivation_step_t step_arg,
+                          uint64_t data_arg)
+            : KDF_input(step_arg) {
+            data = data_arg;
+        }
+
+        virtual psa_status_t input(psa_key_derivation_operation_t *operation) override {
+            return psa_key_derivation_input_integer(operation, step, data);
+        }
+    };
+
+    class KeyDerivationOperation {
+        psa_key_derivation_operation_t operation = PSA_KEY_DERIVATION_OPERATION_INIT;
+
+    public:
+        KeyDerivationOperation() {
+        }
+        ~KeyDerivationOperation() {
+            psa_key_derivation_abort(&operation);
+        }
+
+        psa_status_t setup(psa_algorithm_t alg) {
+            return psa_key_derivation_setup(&operation, alg);
+        }
+
+        psa_status_t input(KDF_input &inp) {
+            return inp.input(&operation);
+        }
+
+        size_t capacity() {
+            size_t cap;
+            CF_ASSERT_PSA(psa_key_derivation_get_capacity(&operation, &cap));
+            return cap;
+        }
+
+        psa_status_t output(std::vector<uint8_t> &out) {
+            return psa_key_derivation_output_bytes(&operation,
+                                                   out.data(), out.size());
+        }
+    };
+
 }
 
 static std::optional<component::Digest> hash_compute(operation::Digest& op,
@@ -1060,6 +1142,123 @@ std::optional<component::Cleartext> TF_PSA_Crypto::OpSymmetricDecrypt(operation:
         return std::nullopt;
     }
     return Buffer(output);
+}
+
+static std::optional<component::Key> kdf_common(operation::Operation &op,
+                                                psa_algorithm_t alg,
+                                                const std::vector<TF_PSA_Crypto_detail::KDF_input*> &inputs,
+                                                size_t output_length) {
+    Datasource ds(op.modifier.GetPtr(), op.modifier.GetSize());
+    TF_PSA_Crypto_detail::SetGlobalDs(&ds);
+    std::optional<component::Key> output_maybe = std::nullopt;
+
+    TF_PSA_Crypto_detail::KeyDerivationOperation operation;
+    CF_ASSERT_PSA(operation.setup(alg));
+    for (auto inp : inputs) {
+        CF_ASSERT_PSA(operation.input(*inp));
+    }
+
+    CF_CHECK_LTE(output_length, operation.capacity());
+
+    {
+        auto output = std::vector<uint8_t>(output_length);
+        CF_ASSERT_PSA(operation.output(output));
+        output_maybe = Buffer(output);
+    }
+
+end:
+    TF_PSA_Crypto_detail::UnsetGlobalDs();
+    return output_maybe;
+}
+
+std::optional<component::Key> TF_PSA_Crypto::OpKDF_HKDF(operation::KDF_HKDF& op) {
+    std::optional<component::Key> result = std::nullopt;
+    Datasource ds(op.modifier.GetPtr(), op.modifier.GetSize());
+    bool const extract_then_expand = ds.Get<bool>();
+    std::vector<TF_PSA_Crypto_detail::KDF_input*> inputs = {
+        new TF_PSA_Crypto_detail::KDF_input_bytes(PSA_KEY_DERIVATION_INPUT_SALT, op.salt),
+        new TF_PSA_Crypto_detail::KDF_input_bytes(PSA_KEY_DERIVATION_INPUT_SECRET, op.password),
+        new TF_PSA_Crypto_detail::KDF_input_bytes(PSA_KEY_DERIVATION_INPUT_INFO, op.info),
+    };
+    psa_algorithm_t const hash_alg =
+        TF_PSA_Crypto_detail::digest_to_psa_algorithm_t(op.digestType);
+
+    /* Skip unknown algorithms */
+    CF_CHECK_NE(hash_alg, PSA_ALG_NONE);
+
+    if (extract_then_expand) {
+        TF_PSA_Crypto_detail::KDF_input* info = inputs[2];
+        inputs.erase(inputs.begin() + 2);
+        result = kdf_common(op, PSA_ALG_HKDF_EXTRACT(hash_alg),
+                            inputs, PSA_HASH_LENGTH(hash_alg));
+        if (!result) {
+            goto end;
+        }
+
+        delete inputs[0];
+        inputs[0] = new TF_PSA_Crypto_detail::KDF_input_bytes(
+            PSA_KEY_DERIVATION_INPUT_SECRET,
+            result->GetConstVectorPtr());
+        delete inputs[1];
+        inputs[1] = info;
+        result = kdf_common(op, PSA_ALG_HKDF_EXPAND(hash_alg), inputs, op.keySize);
+    } else {
+        result = kdf_common(op, PSA_ALG_HKDF(hash_alg), inputs, op.keySize);
+    }
+
+end:
+    for (auto inp : inputs) {
+        delete inp;
+    }
+    return result;
+}
+
+std::optional<component::Key> TF_PSA_Crypto::OpKDF_TLS1_PRF(operation::KDF_TLS1_PRF& op) {
+    std::optional<component::Key> result = std::nullopt;
+    const std::vector<TF_PSA_Crypto_detail::KDF_input*> inputs = {
+        new TF_PSA_Crypto_detail::KDF_input_bytes(PSA_KEY_DERIVATION_INPUT_SEED, op.seed),
+        new TF_PSA_Crypto_detail::KDF_input_bytes(PSA_KEY_DERIVATION_INPUT_SECRET, op.secret),
+        // OpenSSL only supports an empty label
+        new TF_PSA_Crypto_detail::KDF_input_bytes(PSA_KEY_DERIVATION_INPUT_LABEL, component::Cleartext()),
+    };
+    psa_algorithm_t const hash_alg =
+        TF_PSA_Crypto_detail::digest_to_psa_algorithm_t(op.digestType);
+
+    /* Skip unknown or rejected algorithms */
+    CF_CHECK_TRUE(hash_alg == PSA_ALG_SHA_256 || hash_alg == PSA_ALG_SHA_384);
+
+    result = kdf_common(op, PSA_ALG_TLS12_PRF(hash_alg), inputs, op.keySize);
+
+end:
+    for (auto inp : inputs) {
+        delete inp;
+    }
+    return result;
+}
+
+std::optional<component::Key> TF_PSA_Crypto::OpKDF_PBKDF2(operation::KDF_PBKDF2& op) {
+    std::optional<component::Key> result = std::nullopt;
+    const std::vector<TF_PSA_Crypto_detail::KDF_input*> inputs = {
+        new TF_PSA_Crypto_detail::KDF_input_integer(PSA_KEY_DERIVATION_INPUT_COST, op.iterations),
+        new TF_PSA_Crypto_detail::KDF_input_bytes(PSA_KEY_DERIVATION_INPUT_SALT, op.salt),
+        new TF_PSA_Crypto_detail::KDF_input_bytes(PSA_KEY_DERIVATION_INPUT_PASSWORD, op.password),
+    };
+    psa_algorithm_t const hash_alg =
+        TF_PSA_Crypto_detail::digest_to_psa_algorithm_t(op.digestType);
+
+    /* Skip unknown algorithms */
+    CF_CHECK_NE(hash_alg, PSA_ALG_NONE);
+
+    CF_CHECK_NE(op.iterations, 0);
+    CF_CHECK_LTE(op.iterations, PSA_VENDOR_PBKDF2_MAX_ITERATIONS);
+
+    result = kdf_common(op, PSA_ALG_PBKDF2_HMAC(hash_alg), inputs, op.keySize);
+
+end:
+    for (auto inp : inputs) {
+        delete inp;
+    }
+    return result;
 }
 
 } /* namespace module */

--- a/modules/tf-psa-crypto/module.h
+++ b/modules/tf-psa-crypto/module.h
@@ -16,6 +16,9 @@ class TF_PSA_Crypto : public Module {
         std::optional<component::MAC> OpCMAC(operation::CMAC& op) override;
         std::optional<component::Ciphertext> OpSymmetricEncrypt(operation::SymmetricEncrypt& op) override;
         std::optional<component::Cleartext> OpSymmetricDecrypt(operation::SymmetricDecrypt& op) override;
+        std::optional<component::Key> OpKDF_HKDF(operation::KDF_HKDF& op) override;
+        std::optional<component::Key> OpKDF_TLS1_PRF(operation::KDF_TLS1_PRF& op) override;
+        std::optional<component::Key> OpKDF_PBKDF2(operation::KDF_PBKDF2& op) override;
 };
 
 } /* namespace module */

--- a/util.cpp
+++ b/util.cpp
@@ -129,6 +129,26 @@ Multipart ToEqualParts(const uint8_t* data, const size_t size, const size_t part
     return ret;
 }
 
+MultipartOutput ToParts(fuzzing::datasource::Datasource& ds, std::vector<uint8_t>& buffer, const size_t blocksize) {
+    return ToParts(ds, buffer.data(), buffer.size(), blocksize);
+}
+
+MultipartOutput ToParts(fuzzing::datasource::Datasource& ds, uint8_t* data, const size_t size, const size_t blocksize) {
+    const bool blocks = blocksize != 0;
+    const auto parts = Split(ds, !blocks ? size : size / blocksize);
+    MultipartOutput ret;
+    size_t curPos = 0;
+    for (auto& p : parts) {
+        const size_t n = !blocks ? p : blocksize * p;
+        ret.push_back({data + curPos, n});
+        curPos += n;
+    }
+    if ( curPos < size ) {
+        ret.push_back({data + curPos, size - curPos});
+    }
+    return ret;
+}
+
 std::vector<uint8_t> Pkcs7Pad(std::vector<uint8_t> in, const size_t blocksize) {
     size_t numPadBytes = blocksize - (in.size() % blocksize);
 


### PR DESCRIPTION
Add support for the KDF that Cryptofuzz and PSA Crypto have in common: HKDF, TLS1.2_PRF with an empty label, and PBKDF2-HMAC.

Status: I think one-shot output is working fine, but multipart output isn't. With some inputs, LeakSanitizer complains that resources allocated in the caller of `kdf_common` aren't freed. With a debugger, I can see that this is because `bool const multipart = ds.Get<bool>()` raises an `OutOfData()` exception (which IIUC bypasses the destructors of local variables of `kdf_common`, but gets caught later). I can't figure out why the `OutOfData` exception is raised. How do datasources work? What makes them run out?