### PR TITLE
doc: remove `--with-bignum` from secp256k1 configure

### DIFF
--- a/docs/secp256k1.md
+++ b/docs/secp256k1.md
@@ -6,7 +6,7 @@
 git clone --depth 1 https://github.com/bitcoin-core/secp256k1.git
 cd secp256k1/
 autoreconf -ivf
-./configure --enable-static --disable-tests --disable-benchmark --with-bignum=no --disable-exhaustive-tests --enable-module-recovery --enable-module-schnorrsig --enable-experimental --enable-module-ecdh
+./configure --enable-static --disable-tests --disable-benchmark --disable-exhaustive-tests --enable-module-recovery --enable-module-schnorrsig --enable-experimental --enable-module-ecdh
 make
 export SECP256K1_INCLUDE_PATH=$(realpath .)
 export LIBSECP256K1_A_PATH=$(realpath .libs/libsecp256k1.a)


### PR DESCRIPTION
It was removed in https://github.com/bitcoin-core/secp256k1/pull/831, and results in:
```bash
configure: WARNING: unrecognized options: --with-bignum
```