### PR TITLE
botan: remove `botan/internal/curve_nistp.h` include

### DIFF
--- a/modules/botan/bn_ops.cpp
+++ b/modules/botan/bn_ops.cpp
@@ -4,7 +4,6 @@
 #include <botan/numthry.h>
 #include <botan/reducer.h>
 #include <botan/internal/divide.h>
-#include <botan/internal/curve_nistp.h>
 #include <botan/internal/primality.h>
 #include <botan/system_rng.h>
 


### PR DESCRIPTION
Probably should have been part of 687d3064c5cef2b0fe1f30824065a2f2c9c0bbd8.

The header was removed as part of https://github.com/randombit/botan/pull/4385, and it's inclusion is causing build issues downstream, i.e: https://github.com/google/oss-fuzz/pull/12659.