### PR TITLE
Fix UBSan runtime error

### DIFF
--- a/fuzzing-headers/include/fuzzing/datasource/datasource.hpp
+++ b/fuzzing-headers/include/fuzzing/datasource/datasource.hpp
@@ -194,6 +194,10 @@ void Datasource::put(const void* p, const size_t size, const uint64_t id) {
         memcpy(out.data() + oldSize, &_size, sizeof(_size));
     }
 
+    if ( size == 0 ) {
+        return;
+    }
+
     {
         const auto oldSize = out.size();
         out.resize(oldSize + size);


### PR DESCRIPTION
When compiling and running CryptoFuzz locally, I came across this error:
```
$ UBSAN_OPTIONS=halt_on_error=1,print_stacktrace=1 ./cryptofuzz
INFO: found LLVMFuzzerCustomMutator (0x5dbbb07e0c28). Disabling -len_control by default.
INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 921482719
INFO: Loaded 1 modules   (283641 inline 8-bit counters): 283641 [0x5dbbb1b6cca8, 0x5dbbb1bb20a1), 
INFO: Loaded 1 PC tables (283641 PCs): 283641 [0x5dbbb1bb20a8,0x5dbbb2006038), 
INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 4096 bytes
INFO: A corpus is not provided, starting from an empty corpus
#2	INITED cov: 124 ft: 125 corp: 1/1b exec/s: 0 rss: 81Mb
	NEW_FUNC[1/34]: 0x5dbbb019da20 in std::__cxx1998::vector<unsigned char, std::allocator<unsigned char>>::vector(std::__cxx1998::vector<unsigned char, std::allocator<unsigned char>> const&) /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/stl_vector.h:604
	NEW_FUNC[2/34]: 0x5dbbb019dcb8 in unsigned char* std::copy<__gnu_cxx::__normal_iterator<unsigned char const*, std::__cxx1998::vector<unsigned char, std::allocator<unsigned char>>>, unsigned char*>(__gnu_cxx::__normal_iterator<unsigned char const*, std::__cxx1998::vector<unsigned char, std::allocator<unsigned char>>>, __gnu_cxx::__normal_iterator<unsigned char const*, std::__cxx1998::vector<unsigned char, std::allocator<unsigned char>>>, unsigned char*) /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/stl_algobase.h:625
#3	NEW    cov: 310 ft: 319 corp: 2/644b lim: 4096 exec/s: 0 rss: 83Mb L: 643/643 MS: 1 Custom-
fuzzing-headers/include/fuzzing/datasource/datasource.hpp:200:38: runtime error: null pointer passed as argument 2, which is declared to never be null
/usr/include/string.h:44:28: note: nonnull attribute specified here
    #0 0x5dbbb0298d11 in fuzzing::datasource::Datasource::put(void const*, unsigned long, unsigned long) /home/mdauer/github/cryptofuzz/fuzzing-headers/include/fuzzing/datasource/datasource.hpp:200:9
    #1 0x5dbbb0204c98 in cryptofuzz::Buffer::Serialize(fuzzing::datasource::Datasource&) const /home/mdauer/github/cryptofuzz/components.cpp:119:8
    #2 0x5dbbb0204c98 in cryptofuzz::Bignum::Serialize(fuzzing::datasource::Datasource&) const /home/mdauer/github/cryptofuzz/components.cpp:386:10
    #3 0x5dbbb0204c98 in cryptofuzz::component::BignumPair::Serialize(fuzzing::datasource::Datasource&) const /home/mdauer/github/cryptofuzz/components.cpp:475:11
    #4 0x5dbbb02094de in cryptofuzz::component::G2::Serialize(fuzzing::datasource::Datasource&) const /home/mdauer/github/cryptofuzz/components.cpp:625:11
    #5 0x5dbbb0809812 in LLVMFuzzerCustomMutator /home/mdauer/github/cryptofuzz/mutator.cpp:2690:24
    #6 0x5dbbb00b64b4 in fuzzer::MutationDispatcher::MutateImpl(unsigned char*, unsigned long, unsigned long, std::vector<fuzzer::MutationDispatcher::Mutator, std::allocator<fuzzer::MutationDispatcher::Mutator>>&) (/home/mdauer/github/cryptofuzz/cryptofuzz+0xe2e4b4) (BuildId: dc372d82713f74d711a1edc137a4630c07ab2918)
    #7 0x5dbbb00a3cb1 in fuzzer::Fuzzer::MutateAndTestOne() (/home/mdauer/github/cryptofuzz/cryptofuzz+0xe1bcb1) (BuildId: dc372d82713f74d711a1edc137a4630c07ab2918)
    #8 0x5dbbb00a4845 in fuzzer::Fuzzer::Loop(std::vector<fuzzer::SizedFile, std::allocator<fuzzer::SizedFile>>&) (/home/mdauer/github/cryptofuzz/cryptofuzz+0xe1c845) (BuildId: dc372d82713f74d711a1edc137a4630c07ab2918)
    #9 0x5dbbb0091b1f in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/home/mdauer/github/cryptofuzz/cryptofuzz+0xe09b1f) (BuildId: dc372d82713f74d711a1edc137a4630c07ab2918)
    #10 0x5dbbb00bc1a6 in main (/home/mdauer/github/cryptofuzz/cryptofuzz+0xe341a6) (BuildId: dc372d82713f74d711a1edc137a4630c07ab2918)
    #11 0x7e9286a2a1c9 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #12 0x7e9286a2a28a in __libc_start_main csu/../csu/libc-start.c:360:3
    #13 0x5dbbb0086b04 in _start (/home/mdauer/github/cryptofuzz/cryptofuzz+0xdfeb04) (BuildId: dc372d82713f74d711a1edc137a4630c07ab2918)

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior fuzzing-headers/include/fuzzing/datasource/datasource.hpp:200:38 
MS: 0 ; base unit: adc83b19e793491b1c6ea0fd8b46cd9f32e592fc


artifact_prefix='./'; Test unit written to ./crash-da39a3ee5e6b4b0d3255bfef95601890afd80709
Base64: 
```

If `size` is `0`, `p` may be a `nullptr` resulting in undefined behaviour when calling `memcpy` here: https://github.com/guidovranken/cryptofuzz/blob/f15774589efb158f9767e081327254926f9e36f5/fuzzing-headers/include/fuzzing/datasource/datasource.hpp#L200

This probably fixes the runtime error mentioned in #38.